### PR TITLE
Fix missing cloudsql empty directory.

### DIFF
--- a/cloudsql/cloudsql_deployment.yaml
+++ b/cloudsql/cloudsql_deployment.yaml
@@ -48,6 +48,8 @@ spec:
               readOnly: true
             - name: ssl-certs
               mountPath: /etc/ssl/certs
+            - name: cloudsql
+              mountPath: /cloudsql
         # [END proxy_container]
       # [START volumes]
       volumes:
@@ -57,4 +59,6 @@ spec:
         - name: ssl-certs
           hostPath:
             path: /etc/ssl/certs
+        - name: cloudsql
+          emptyDir:
       # [END volumes]


### PR DESCRIPTION
Missing directory cloudsql which should be a`emptyDir`. As a result, the pod cannot run.