### PR TITLE
CONTRIBUTING.md: fix markdown link rendering

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,12 +8,12 @@ have to jump a couple of legal hurdles.
 Please fill out either the individual or corporate Contributor License Agreement
 (CLA).
 
-  * If you are an individual writing original source code and you're sure you
-    own the intellectual property, then you'll need to sign an [individual CLA]
-    (https://developers.google.com/open-source/cla/individual).
-  * If you work for a company that wants to allow you to contribute your work,
-    then you'll need to sign a [corporate CLA]
-    (https://developers.google.com/open-source/cla/corporate).
+* If you are an individual writing original source code and you're sure you own
+  the intellectual property, then you'll need to sign an [individual
+  CLA](https://developers.google.com/open-source/cla/individual).
+* If you work for a company that wants to allow you to contribute your work,
+  then you'll need to sign a [corporate
+  CLA](https://developers.google.com/open-source/cla/corporate).
 
 Follow either of the two links above to access the appropriate CLA and
 instructions for how to sign and return it. Once we receive it, we'll be able to


### PR DESCRIPTION
Links are currently not rendering well due to the line breaks between `[]` and `()`.