### PR TITLE
hellonode: Handle SIGINT, add hostname and \n to response

### DIFF
--- a/hellonode/server.js
+++ b/hellonode/server.js
@@ -15,11 +15,19 @@
  */
 
 var http = require('http');
+var os = require('os');
+
+process.on('SIGINT', function() {
+  console.log('shutting down...');
+  process.exit();
+});
 
 var handleRequest = function(request, response) {
   console.log('Received request for URL: ' + request.url);
   response.writeHead(200);
-  response.end('Hello, World!');
+  response.end('Hello, World!\nHostname: ' + os.hostname() + '\n');
 };
+
 var www = http.createServer(handleRequest);
+console.log('server listening on port 8080');
 www.listen(8080);

--- a/hellonode/server.js
+++ b/hellonode/server.js
@@ -14,20 +14,23 @@
  * limitations under the License.
  */
 
-var http = require('http');
-var os = require('os');
+const http = require('http');
+const os = require('os');
+
+const port = process.env.PORT || 8080;
 
 process.on('SIGINT', function() {
   console.log('shutting down...');
-  process.exit();
+  process.exit(1);
 });
 
 var handleRequest = function(request, response) {
-  console.log('Received request for URL: ' + request.url);
+  console.log(`Received request for URL: ${request.url}`);
   response.writeHead(200);
-  response.end('Hello, World!\nHostname: ' + os.hostname() + '\n');
+  response.end(`Hello, World!\nHostname: ${os.hostname()}\n`);
 };
 
 var www = http.createServer(handleRequest);
-console.log('server listening on port 8080');
-www.listen(8080);
+www.listen(port, () => {
+  console.log(`server listening on port ${port}`);
+});


### PR DESCRIPTION
- Ctrl+C on a Docker container sends SIGINT, which is not handled
  properly by default (see nodejs/node#4182). Added a signal handler.
- Adding trailing newline to response for curl-friendliness.
- Added log message indicating server is starting.
- Added hostname to indicate that the container.

Signed-off-by: Ahmet Alp Balkan <ahmetb@google.com>