### PR TITLE
Import manifests for persistent-disk tutorial

### DIFF
--- a/wordpress-persistent-disks/README.md
+++ b/wordpress-persistent-disks/README.md
@@ -1,0 +1,5 @@
+# Using Persistent Disks with WordPress and MySQL
+
+Follow this tutorial at https://cloud.google.com/container-engine/docs/tutorials/persistent-disk/
+
+

--- a/wordpress-persistent-disks/mysql-service.yaml
+++ b/wordpress-persistent-disks/mysql-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+  labels:
+    app: mysql
+spec:
+  type: ClusterIP
+  ports:
+    - port: 3306
+  selector:
+    app: mysql

--- a/wordpress-persistent-disks/mysql.yaml
+++ b/wordpress-persistent-disks/mysql.yaml
@@ -1,0 +1,36 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: mysql
+  labels:
+    app: mysql
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mysql
+  template:
+    metadata:
+      labels:
+        app: mysql
+    spec:
+      containers:
+        - image: mysql:5.6
+          name: mysql
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mysql
+                  key: password
+          ports:
+            - containerPort: 3306
+              name: mysql
+          volumeMounts:
+            - name: mysql-persistent-storage
+              mountPath: /var/lib/mysql
+      volumes:
+        - name: mysql-persistent-storage
+          gcePersistentDisk:
+            pdName: mysql-disk
+            fsType: ext4

--- a/wordpress-persistent-disks/wordpress-service.yaml
+++ b/wordpress-persistent-disks/wordpress-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: wordpress
+  name: wordpress
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+  selector:
+    app: wordpress

--- a/wordpress-persistent-disks/wordpress.yaml
+++ b/wordpress-persistent-disks/wordpress.yaml
@@ -1,0 +1,38 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: wordpress
+  labels:
+    app: wordpress
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wordpress
+  template:
+    metadata:
+      labels:
+        app: wordpress
+    spec:
+      containers:
+        - image: wordpress
+          name: wordpress
+          env:
+          - name: WORDPRESS_DB_HOST
+            value: mysql:3306
+          - name: WORDPRESS_DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: mysql
+                key: password
+          ports:
+            - containerPort: 80
+              name: wordpress
+          volumeMounts:
+            - name: wordpress-persistent-storage
+              mountPath: /var/www/html
+      volumes:
+        - name: wordpress-persistent-storage
+          gcePersistentDisk:
+            pdName: wordpress-disk
+            fsType: ext4


### PR DESCRIPTION
This tutorial's contents used to be served in a .zip on cloud.google.com,
now moving them here and updating. Major changes:

- use `Service` to do discovery instead of docker-links style env vars
- use Deployment instead of `Pod` deployment
- extract mysql root password to a `Secret` instead of embedding in YAML

Contact me for internal link to review the new tutorial if necessary.

Signed-off-by: Ahmet Alp Balkan <ahmetb@google.com>