### PR TITLE
update service name to avoid conflict

### DIFF
--- a/wordpress-persistent-disks/mysql-service.yaml
+++ b/wordpress-persistent-disks/mysql-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: mysql
+  name: mysql-service
   labels:
     app: mysql
 spec:


### PR DESCRIPTION
If metadata name is same as app selector it causes pod to keep crashing
see https://github.com/kubernetes/kubernetes/issues/16906