### PR TITLE
Updated hello-app/Dockerfile to be more friendly to older docker versions

### DIFF
--- a/hello-app/Dockerfile
+++ b/hello-app/Dockerfile
@@ -1,8 +1,6 @@
 FROM golang:1.8-alpine
-ADD . /go/src/hello-app
-RUN go install hello-app
-
-FROM alpine:latest
-COPY --from=0 /go/bin/hello-app .
+ADD . /hello-app
+WORKDIR /hello-app
+RUN go build -o main .
 ENV PORT 8080
-CMD ["./hello-app"]
+CMD ["/hello-app/main"]


### PR DESCRIPTION
@lesv 

This removes the multi-staging from the Dockerfile, which requires Docker 1.17.05 or higher. G-Cloud webshell runs a lower version than this. 

Previously the docker compiled the app in one stage and then copied into another one for minimization. This change just builds and hosts the app in the same container since multi-staging isn't possible. 