### PR TITLE
Revert #28

### DIFF
--- a/hello-app/Dockerfile
+++ b/hello-app/Dockerfile
@@ -1,6 +1,8 @@
 FROM golang:1.8-alpine
-ADD . /hello-app
-WORKDIR /hello-app
-RUN go build -o main .
+ADD . /go/src/hello-app
+RUN go install hello-app
+
+FROM alpine:latest
+COPY --from=0 /go/bin/hello-app .
 ENV PORT 8080
-CMD ["/hello-app/main"]
+CMD ["./hello-app"]


### PR DESCRIPTION
This reverts PR #28 (commit 78db85e2afa2c0cf7492bc013ce21fdc45e228a7).

Cloud Shell now has docker-17.05 which can do multi-stage builds.

FYI @kurtisvg @lesv 