### PR TITLE
Update cloudsql_deployment.yaml

### DIFF
--- a/cloudsql/cloudsql_deployment.yaml
+++ b/cloudsql/cloudsql_deployment.yaml
@@ -15,9 +15,9 @@ spec:
           env:
             - name: WORDPRESS_DB_HOST
               # Connect to the SQL proxy over the local network on a fixed port.
-              # Change the [PORT] to the port number used by your database
-              # (e.g. 3306).
-              value: 127.0.0.1:[PORT]
+              # Change the <PORT> to the port number used by your database
+              # (e.g. 3306 for MySQL or 5432 for PostgreSQL).
+              value: 127.0.0.1:<PORT>
             # These secrets are required to start the pod.
             # [START cloudsql_secrets]
             - name: WORDPRESS_DB_PASSWORD
@@ -34,16 +34,16 @@ spec:
           ports:
             - containerPort: 80
               name: wordpress
-        # Change [INSTANCE_CONNECTION_NAME] here to include your GCP
+        # Change <INSTANCE_CONNECTION_NAME> here to include your GCP
         # project, the region of your Cloud SQL instance and the name
         # of your Cloud SQL instance. The format is
         # $PROJECT:$REGION:$INSTANCE
         # Insert the port number used by your database.
         # [START proxy_container]
-        - image: gcr.io/cloudsql-docker/gce-proxy:1.09
+        - image: gcr.io/cloudsql-docker/gce-proxy:1.11
           name: cloudsql-proxy
           command: ["/cloud_sql_proxy", "--dir=/cloudsql",
-                    "-instances=[INSTANCE_CONNECTION_NAME]=tcp:[PORT]",
+                    "-instances=<INSTANCE_CONNECTION_NAME>=tcp:<PORT>",
                     "-credential_file=/secrets/cloudsql/credentials.json"]
           volumeMounts:
             - name: cloudsql-instance-credentials


### PR DESCRIPTION
Apparently we've had several users lately who did not realize they needed to remove the square brackets around INSTANCE_CONNECTION_NAME. This could be because of the (required) square brackets around the entire command. Switched to angle brackets instead. Also, updated proxy version to most recent.