### PR TITLE
Add 0.0.0.0 to proxy connection string

### DIFF
--- a/cloudsql/cloudsql_deployment.yaml
+++ b/cloudsql/cloudsql_deployment.yaml
@@ -43,7 +43,7 @@ spec:
         - image: gcr.io/cloudsql-docker/gce-proxy:1.11
           name: cloudsql-proxy
           command: ["/cloud_sql_proxy", "--dir=/cloudsql",
-                    "-instances=<INSTANCE_CONNECTION_NAME>=tcp:<PORT>",
+                    "-instances=<INSTANCE_CONNECTION_NAME>=tcp:0.0.0.0:<PORT>",
                     "-credential_file=/secrets/cloudsql/credentials.json"]
           volumeMounts:
             - name: cloudsql-instance-credentials


### PR DESCRIPTION
As per pull request here (actually only a comment addition):
https://github.com/GoogleCloudPlatform/cloudsql-proxy/pull/127

I believe we need the 0.0.0.0 in this file also.